### PR TITLE
Fix parsing for empty strings

### DIFF
--- a/source/src/ch24/batch01/parse/StringLiteralParse.php
+++ b/source/src/ch24/batch01/parse/StringLiteralParse.php
@@ -34,7 +34,7 @@ class StringLiteralParse extends Parser
             $string .= $scanner->token();
         }
 
-        if ($string && ! $this->discard) {
+        if ($ret && ! $this->discard) {
             $scanner->getContext()->pushResult($string);
         }
 


### PR DESCRIPTION
Checking for $string would return false in case the string is empty